### PR TITLE
add anchor name to avoid hardcoded section number in link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -36,7 +36,7 @@ This is at deployment time, when all the services collaborate together that we c
 
 The deployment is described in details in the https://github.com/cloudstateio/samples-ui-chat[Cloudstate Chat Sample].
 
-
+[[js-devenv-setup-for-cloudstate]]
 == Javascript Dev environment setup for Cloudstate
 
 === Javascript 

--- a/friends/README.adoc
+++ b/friends/README.adoc
@@ -173,6 +173,7 @@ entity.commandHandlers = {
 entity.start();
 ----
 
+[[building-the-friends-service]]
 == Building the Friends service
 
 === Build the Docker image
@@ -206,10 +207,9 @@ docker login
 docker push $DOCKER_PUBLISH_TO/samples-js-chat-friends:latest
 ----
 
+[[testing-friends-service]]
+== Testing Friends service
 
-== Testing
-
-[[testing-start-service]]
 === Starting the service
 
 We cannot test the `Friends` service by querying it directly. Why is that? In the <<javascript-implementation>> section, the Javascript code we wrote barely defines the data schema and the behavior of the service. And yet we have a full blown stateful service, ie. the service is able to store/retrieve the `FriendList` of an user entity. And this, with the benefits of scalability and high availability, without writing any code for the state storage & retrieval.

--- a/presence/README.adoc
+++ b/presence/README.adoc
@@ -24,11 +24,12 @@ to track the state (online/offline status) of the user entity:
 
 The diagram below shows the chat application is architected as 3 microservices, deployed in a Kubernetes cluster. 
 
-For now, let's ignore the application flow which is explained in https://github.com/cloudstateio/samples-ui-chat[Cloudstate Chat Sample]. Also, we'll skip the coding tutorial which is very similar to that of the `Friends` service: <<../friends/README.adoc#javascript-implementation, Javascript implementation of the Friends service>>. In this section, we focus only on the build and the testing of the `Presence` service:
+For now, let's ignore the application flow which is explained in https://github.com/cloudstateio/samples-ui-chat[Cloudstate Chat Sample]. Also, we'll skip the coding tutorial which is very similar to that of the `Friends` service: <<../friends/README.adoc#javascript-implementation,Javascript implementation of the Friends service>>. In this section, we focus only on the build and the testing of the `Presence` service:
 
 image::../docs/ChatAppDiagram_HighlightPresenceService.png[Chat Sample Diagram]
 
 
+[[building-the-presence-service]]
 == Building the Presence service
 
 === Build the Docker image
@@ -66,7 +67,7 @@ docker push $DOCKER_PUBLISH_TO/samples-js-chat-presence:latest
 
 === Starting the service
 
-Testing the `Presence` service follows the same procedure as that of the `Friends` service. You may want to read the <<../friends/README.adoc#testing-start-service,Testing Friends service>> section for a more detailed introduction. Here we proceed directly to starting the docker images:
+Testing the `Presence` service follows the same procedure as that of the `Friends` service. You may want to read the <<../friends/README.adoc#testing-friends-service,Testing Friends service>> section for a more detailed introduction. Here we proceed directly to starting the docker images:
 
 [source,shell]
 ----


### PR DESCRIPTION
Minor update: The READMEs in `samples-js-chat` are referred as external links in `samples-ui-chat`. Some sections has a link with the section number generated automatically, eg "README.doc#**4.**Testing-Friends-Service" (notice the number 4).

This causes the link to be unreliable, because the section number is unstable. In furture update, the number might be different. Now replaced with anchor name, which is constant in time.

NOTE: this change is guaranteed no conflict. You can forward merge by choosing the button "Rebase and Merge"