### PR TITLE
Add initial response for presence connect

### DIFF
--- a/presence/presence.js
+++ b/presence/presence.js
@@ -47,6 +47,7 @@ function connect(user, ctx) {
     };
     ctx.state.connect();
   }
+  return {};
 }
 
 /**


### PR DESCRIPTION
Add an empty response for the `connect` method, to allow the stream to be cancelled with newer versions of Cloudstate, due to https://github.com/cloudstateio/cloudstate/issues/493. This still works with older Cloudstate versions as well.